### PR TITLE
Add retry queue based on dead-lettering and message TTL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:latest
+      - image: rabbitmq:latest
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - bundler-cache-{{ checksum "ptt.gemspec" }}
+      - run:
+          name: Install gems dependencies
+          command: bundle install --jobs=10 --path vendor/bundle
+      - save_cache:
+          key: bundler-cache-{{ checksum "ptt.gemspec" }}
+          paths:
+            - vendor/bundle
+      - run:
+          name: Wait for RabbitMQ
+          command: dockerize -wait tcp://localhost:5672 -timeout 1m
+      - run:
+          name: Run RSpec tests
+          command: bundle exec rspec -I .
+          environment:
+            RABBITMQ_URL: amqp://localhost:5672
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ruby:2.5.1
+
+ENV LANG C.UTF-8
+
+# Install dependencies.
+#
+# build-essential       - To ensure certain gems can be compiled.
+# libpq-dev             - Communicate with postgres through the postgres gem.
+# postgresql-client     - In case of direct access to PostgreSQL,
+#                         e.g. `rake db:structure:load` depends on psql.
+RUN apt-get update \
+    && apt-get install -y \
+                       --no-install-recommends \
+                       build-essential
+
+# Create an unprivileged user, prosaically called app, to run the app inside
+# the container. If you don’t do this, then the process inside the container
+# will run as root, which is against security best practices and principles.
+RUN useradd --user-group \
+            --create-home \
+            --shell /bin/false \
+            app
+
+ENV HOME=/home/app
+WORKDIR $HOME
+
+USER app
+
+COPY --chown=app:app Gemfile \
+                     Gemfile.lock \
+                     ptt.gemspec \
+                     $HOME/
+COPY --chown=app:app lib/ptt/version.rb \
+                     $HOME/lib/ptt/
+RUN bundle install --jobs=20 \
+                   --clean
+
+COPY --chown=app:app . $HOME/
+
+CMD ["irb"]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ PTT.publish('bar', data)
 
 In case you need to requeue rejected messages there are two option available:
 
- - Via environment variable: `PTT_REQUEUE_REJECTED_MESSAGE=true`.
+ - Via environment variable: `PTT_DEFAULT_RETRY=true`.
 This will override the default requeue value for the whole project.
 
  - Per handler, example:
@@ -94,7 +94,7 @@ end
 
 ## Testing
 
-    $ bundle exec rake
+    $ script/test
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,0 @@
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
-
-RSpec::Core::RakeTask.new
-
-task default: :spec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.1"
+
+services:
+  tester:
+    depends_on:
+      - rabbitmq
+    environment:
+      - RABBITMQ_URL=amqp://rabbitmq
+    image: gohiring/ptt:latest
+    volumes:
+      - .:/home/app
+  rabbitmq:
+    image: rabbitmq:latest

--- a/lib/ptt.rb
+++ b/lib/ptt.rb
@@ -6,8 +6,14 @@ require 'ptt/version'
 module PTT
   extend self
 
-  attr_writer :client
   attr_writer :publisher
+
+  def client=(new_client)
+    @client = new_client
+    @consumers = nil
+    @handlers = nil
+    @client
+  end
 
   def configure
     yield(self) if block_given?
@@ -53,7 +59,8 @@ module PTT
     @consumers ||= Hash.new do |repository, routing_key|
       repository[routing_key] = Consumer.new(
         client.channel,
-        client.queue_for(routing_key)
+        client.queue_for(routing_key),
+        client.retry_queue_for(routing_key)
       )
     end
   end

--- a/lib/ptt/amqp_client.rb
+++ b/lib/ptt/amqp_client.rb
@@ -40,10 +40,37 @@ module PTT
       @exchange ||= channel.direct('amq.direct', durable: true)
     end
 
+    def retry_exchange
+      @retry_exchange ||= channel.direct('amq.direct', durable: true)
+    end
+
     def queue_for(routing_key)
       queue = channel.queue(routing_key, durable: true)
       queue.bind(exchange, routing_key: routing_key)
+
       queue
+    end
+
+    # The retry queue must be configured the way that the dead-letter exchange
+    # is set to the main work exchange, so all expired messages are
+    # automatically moved to the work exchange once on the moment of expired
+    # TTL.
+    #
+    # Another important aspect of correctly working retry functionality is
+    # the routing key for dead-lettering. Because the client used exchanges
+    # of direct type, the key must be set. The routing key must match the name
+    # of work queue.
+    def retry_queue_for(routing_key)
+      original_routing_key = routing_key
+      routing_key = "#{routing_key}.retry"
+      retry_queue = channel.queue(routing_key, durable: true,
+                                               arguments: {
+                                                 'x-dead-letter-exchange' => exchange.name,
+                                                 'x-dead-letter-routing-key' => original_routing_key
+                                               })
+      retry_queue.bind(retry_exchange, routing_key: routing_key)
+
+      retry_queue
     end
 
     private

--- a/lib/ptt/consumer.rb
+++ b/lib/ptt/consumer.rb
@@ -1,10 +1,46 @@
 require 'json'
 
 module PTT
+  # Consumer processes incoming messages. It supports auto-retry mechanism
+  # for cases when related handler fails to process a message.
+  #
+  # The auto-retry is based on [dead-lettering functionality provided by
+  # RabbitMQ](https://www.rabbitmq.com/dlx.html). When a call to handler fails
+  # and retry is possible (see below), the message is published to
+  # the special retry queue with a specific TTL. When the message in the retry
+  # queue is expired (dead-lettered), RabbitMQ automatically publishes it
+  # to the work queue again.
+  #
+  #                       work.queue.retry     retry-exchange
+  #                       ┌─┬─┬─┬─┬─┬─┬─┐          .───.
+  #           ┌───────────│ │ │ │ │ │ │ │◀────────(  X  )◀───┐
+  #           │           └─┴─┴─┴─┴─┴─┴─┘          `───'     │
+  #           │                                              │
+  # x-dead-letter-exchange                                   │
+  #         binding                                          │
+  #           │                                              │
+  #           │                                            .───.
+  #           │                                           (  C  ) consumer
+  #           ▼                                            `───'
+  #         .───.         ┌─┬─┬─┬─┬─┬─┬─┐                    ▲
+  # ──────▶(  X  )───────▶│ │ │ │ │ │ │ │────────────────────┘
+  #         `───'         └─┴─┴─┴─┴─┴─┴─┘
+  #     work-exchange     work.queue
+  #
+  # The retry can be possible if the handler responds to `#requeue?` message
+  # and it returns `true` in response. In order to prevent infinite loop of
+  # retries there is a hard limit on the number of possible attempts.
+  #
+  # In case the handler does not implement `#requeue?` method, the environment
+  # variable PTT_DEFAULT_RETRY is used to determine if the consumer should
+  # retry the message delivery.
   class Consumer
-    def initialize(channel, queue)
+    MAX_RETRIES = 10
+
+    def initialize(channel, queue, retry_queue)
       @channel = channel
       @queue = queue
+      @retry_queue = retry_queue
     end
 
     def subscribe(handler)
@@ -12,21 +48,50 @@ module PTT
       @queue.subscribe(manual_ack: true, &method(:receive))
     end
 
+    # The method is called when the consumer received the message from
+    # the queue.
+    #
+    # In case the handler failes to process the payload, the delivery can be
+    # retried. If it is not possible to retry the delivery, then the original
+    # exception is re-raised.
     def receive(delivery_info, properties, body)
       @handler.call(JSON.parse(body))
+    rescue => exception
+      if should_retry?(exception) && can_retry?(properties)
+        retry_delivery(properties, body)
+      else
+        raise exception
+      end
+    ensure
       @channel.ack(delivery_info.delivery_tag)
-    rescue => e
-      @channel.reject(delivery_info.delivery_tag, requeue(e))
     end
 
     private
 
-    def requeue(error)
+    def should_retry?(exception)
       if @handler.respond_to?(:requeue?)
-        @handler.requeue?(error)
+        @handler.requeue?(exception)
       else
-        ENV['PTT_REQUEUE_REJECTED_MESSAGE'] == 'true'
+        ENV['PTT_DEFAULT_RETRY'] == 'true'
       end
+    end
+
+    def can_retry?(properties)
+      headers = properties.headers || {}
+      retry_count = headers.fetch('x-retry-count', 0)
+
+      retry_count < MAX_RETRIES
+    end
+
+    def retry_delivery(properties, body)
+      headers = properties.headers || {}
+      retry_count = headers.fetch('x-retry-count', 0)
+      ttl = ((retry_count**4) + 15 + (rand(30) * (retry_count + 1))).to_i*1000
+
+      headers['x-retry-count'] = retry_count + 1
+
+      @retry_queue.publish(body, expiration: ttl,
+                                 headers: headers)
     end
   end
 end

--- a/lib/ptt/memory_client.rb
+++ b/lib/ptt/memory_client.rb
@@ -47,6 +47,11 @@ module PTT
       queues[routing_key]
     end
 
+    def retry_queue_for(routing_key)
+      routing_key = "#{routing_key}.retry"
+      queues[routing_key]
+    end
+
     private
 
     def queues

--- a/lib/ptt/null_client.rb
+++ b/lib/ptt/null_client.rb
@@ -39,6 +39,11 @@ module PTT
       queues[routing_key]
     end
 
+    def retry_queue_for(routing_key)
+      routing_key = "#{routing_key}.retry"
+      queues[routing_key]
+    end
+
     private
 
     def queues

--- a/ptt.gemspec
+++ b/ptt.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 end

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+#
+# Set up application for the first time after cloning, or set it back to the
+# initial first unused state.
+#
+# Examples
+#
+#   script/setup
+set -o errexit
+
+cd "$(dirname "$0")/.."
+
+echo "==> Building the Docker image…"
+docker build --tag gohiring/ptt:latest .

--- a/script/test
+++ b/script/test
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+#
+# Run test suite for application. Optionally pass in a path to an individual
+# test file to run a single test.
+#
+# Examples
+#
+#   script/test [<FILE>]
+#
+# <FILE> - the path to a spec file.
+set -o errexit
+
+cd "$(dirname "$0")/.."
+
+echo "==> Starting tests…"
+docker-compose run --rm \
+                   tester rspec -I . --color "${@:-spec}"
+

--- a/spec/integration/retry_spec.rb
+++ b/spec/integration/retry_spec.rb
@@ -1,0 +1,32 @@
+require 'ptt'
+require 'ptt/amqp_client'
+
+RSpec.describe 'Retry feature' do
+  let(:client) { PTT::AMQPClient.new }
+
+  before do
+    PTT.client = client
+    PTT.connect
+  end
+
+  after do
+    PTT.disconnect
+  end
+
+  context 'when a handler is registered' do
+    before { PTT.register_handler('foo', Proc.new {}) }
+
+    it 'should create and configure work and retry queues' do
+      queues = client.channel.queues
+      work_queue = queues['foo']
+      retry_queue = queues['foo.retry']
+
+      expect(work_queue).not_to be_nil
+      expect(retry_queue).not_to be_nil
+      expect(retry_queue.arguments).to include({
+        'x-dead-letter-exchange' => client.exchange.name,
+        'x-dead-letter-routing-key' => work_queue.name
+      })
+    end
+  end
+end

--- a/spec/ptt/amqp_client_spec.rb
+++ b/spec/ptt/amqp_client_spec.rb
@@ -1,5 +1,66 @@
 require 'ptt/amqp_client'
 
 RSpec.describe PTT::AMQPClient do
-  pending
+  before { subject.connect }
+
+  after { subject.disconnect }
+
+  describe '#exchange' do
+    it 'should return a direct exchange' do
+      expect(subject.exchange.type).to eq(:direct)
+    end
+
+    it 'should reuse default direct exchange' do
+      expect(subject.exchange.name).to eq('amq.direct')
+    end
+
+    it 'should create a durable exchange' do
+      expect(subject.exchange).to be_durable
+    end
+  end
+
+  describe '#retry_exchange' do
+    it 'should return a direct exchange' do
+      expect(subject.retry_exchange.type).to eq(:direct)
+    end
+
+    it 'should reuse default direct exchange' do
+      expect(subject.retry_exchange.name).to eq('amq.direct')
+    end
+
+    it 'should create a durable exchange' do
+      expect(subject.retry_exchange).to be_durable
+    end
+  end
+
+  describe '#queue_for' do
+    it 'should create a durable queue' do
+      queue = subject.queue_for('foo')
+
+      expect(queue).to be_durable
+    end
+  end
+
+  describe '#retry_queue_for' do
+    it 'should create a durable queue' do
+      queue = subject.retry_queue_for('foo')
+
+      expect(queue).to be_durable
+    end
+
+    it 'should add ".retry" suffix to the given routing key' do
+      queue = subject.retry_queue_for('foo')
+
+      expect(queue.name).to eq('foo.retry')
+    end
+
+    it 'should configure the queue for dead lettering' do
+      queue = subject.retry_queue_for('foo')
+
+      expect(queue.arguments).to include({
+        'x-dead-letter-exchange' => subject.exchange.name,
+        'x-dead-letter-routing-key' => 'foo'
+      })
+    end
+  end
 end

--- a/spec/ptt/memory_client_spec.rb
+++ b/spec/ptt/memory_client_spec.rb
@@ -23,4 +23,10 @@ RSpec.describe PTT::MemoryClient do
       expect(subject.queue_for('foo')).to be_a(PTT::MemoryQueue)
     end
   end
+
+  describe '#retry_queue_for' do
+    it 'returns an instance of MemoryQueue' do
+      expect(subject.retry_queue_for('foo')).to be_a(PTT::MemoryQueue)
+    end
+  end
 end

--- a/spec/ptt/null_client_spec.rb
+++ b/spec/ptt/null_client_spec.rb
@@ -33,4 +33,10 @@ RSpec.describe PTT::NullClient do
       expect(queue1).to be_equal(queue2)
     end
   end
+
+  describe '#retry_queue_for' do
+    it 'returns an instance of NullQueue' do
+      expect(subject.retry_queue_for('foo')).to be_a(PTT::NullQueue)
+    end
+  end
 end


### PR DESCRIPTION
Related issue https://github.com/gohiring/posting/issues/206.

It is now possible to schedule a retry if the handler fails to process the message.

The scheduling part is based on message TTL and [dead-lettering functionality of RabbitMQ](https://www.rabbitmq.com/dlx.html). TTL for each message is calculated using following formula:

    (retry_count ** 4) + 15 + (rand(30) * (retry_count + 1))

It is important to keep in mind that the messages get expired only when they hit the head of the queue. For example, if you have a message with 1h TTL on the head of the queue, messages after that will expire only after the one in the head is. So the TTL times should not be very long.

The general idea is simple. For each work queue there is one additional queue used to keep messages scheduled for retry. All messages in retry queues have specific TTL. Once a message is expired, it is automatically published back to the work queue.

In order to avoid infinite retry loops all failed messages are retried only 10 times. After ten retries
the failing message is rejected from the queue and an exception is raised.